### PR TITLE
[codex] Bundle PDF parser for serverless

### DIFF
--- a/backend/claimcheck/services/ocr.service.js
+++ b/backend/claimcheck/services/ocr.service.js
@@ -2,14 +2,12 @@ import { createRequire } from "module";
 import { fileURLToPath, pathToFileURL } from "url";
 import path from "path";
 import Tesseract from "tesseract.js";
+import { PDFParse } from "pdf-parse";
 import * as pdfjsLib from "pdfjs-dist/legacy/build/pdf.mjs";
 import { createCanvas } from "@napi-rs/canvas";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-// Resolve from the repository root so a stale nested dependency cannot shadow
-// the Vercel production dependency declared in the root package.json.
-const require = createRequire(path.resolve(__dirname, "../../../package.json"));
-const { PDFParse } = require("pdf-parse");
+const require = createRequire(import.meta.url);
 const pdfjsBase = path.dirname(require.resolve("pdfjs-dist/package.json"));
 const standardFontDataUrl =
   pathToFileURL(path.join(pdfjsBase, "standard_fonts")).toString() + "/";


### PR DESCRIPTION
## Fix\nUse a static pdf-parse import so Vercel includes the parser in the serverless bundle.\n\n## Root cause\nThe prior dynamic require was not traced into the deployed function, leaving production unable to extract text from Policy.pdf.\n\n## Validation\n- Reproduced the production failure against qk-my-al-1999-2005.vercel.app.\n- Verified Policy.pdf extracts Ramesh Kumar and KA01AB1234 when loaded using the same root dependency layout used in deployment.\n- npm run lint\n- npm run build